### PR TITLE
Fix google auth flow on nanobanana-ai.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+This is the Nano Banana AI Image Editor (Next.js App Router).
 
 ## Getting Started
 
-First, run the development server:
+Environment variables:
+
+Create a `.env.local` with at least:
+
+```
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+```
+
+Supabase settings:
+- Add Google as an OAuth provider in Supabase Auth.
+- Authorized redirect URLs must include:
+  - http://localhost:3000/auth/callback
+  - https://www.nanobanana-ai.dev/auth/callback
+
+Run the development server:
 
 ```bash
 npm run dev

--- a/SignInModal.jsx
+++ b/SignInModal.jsx
@@ -1,6 +1,6 @@
 "use client"
 import { useState } from "react"
-import { supabase } from "@/lib/supabaseClient"
+import { getSupabase } from "@/lib/supabaseClient"
 
 export default function SignInModal({ open, onClose }) {
   const [email, setEmail] = useState("")
@@ -9,11 +9,15 @@ export default function SignInModal({ open, onClose }) {
 
   if (!open) return null
 
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || (typeof window !== "undefined" ? window.location.origin : "")
+  const callbackUrl = `${baseUrl}/auth/callback`
+
   async function signInWithGoogle() {
     setError("")
+    const supabase = getSupabase()
     const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
-      options: { redirectTo: "https://www.nanobanana-ai.dev/" }
+      options: { redirectTo: callbackUrl }
     })
     if (error) setError(error.message)
   }
@@ -21,9 +25,10 @@ export default function SignInModal({ open, onClose }) {
   async function signInWithEmail(e) {
     e.preventDefault()
     setError("")
+    const supabase = getSupabase()
     const { error } = await supabase.auth.signInWithOtp({
       email,
-      options: { emailRedirectTo: "https://www.nanobanana-ai.dev/" }
+      options: { emailRedirectTo: callbackUrl }
     })
     if (error) setError(error.message)
     else setSent(true)

--- a/app/auth/callback/page.jsx
+++ b/app/auth/callback/page.jsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default function AuthCallbackPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const finalize = async () => {
+      try {
+        const urlError = searchParams?.get("error_description") || searchParams?.get("error");
+        if (urlError) {
+          setError(urlError);
+          return;
+        }
+
+        // Lazy-load Supabase only on the client to avoid build-time env access
+        const { getSupabase } = await import("@/lib/supabaseClient");
+        const supabase = getSupabase();
+        const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(window.location.href);
+        if (exchangeError) {
+          setError(exchangeError.message || "Authentication failed.");
+          return;
+        }
+
+        // Optional: small delay to ensure session propagation
+        setTimeout(() => {
+          if (!isMounted) return;
+          router.replace("/");
+        }, 250);
+      } catch (e) {
+        setError(e?.message || "Authentication failed. Please try again.");
+      }
+    };
+
+    finalize();
+    return () => {
+      isMounted = false;
+    };
+  }, [router, searchParams]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-white p-6">
+      <div className="max-w-md w-full text-center">
+        <h1 className="text-xl font-semibold text-gray-900">Signing you in…</h1>
+        <p className="mt-2 text-sm text-gray-600">Completing Google authentication.</p>
+        {error && (
+          <div className="mt-4 text-sm text-red-600">
+            {error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/app/auth/callback/page.jsx
+++ b/app/auth/callback/page.jsx
@@ -1,12 +1,28 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import React, { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
-export const dynamic = "force-dynamic";
-export const revalidate = 0;
-
 export default function AuthCallbackPage() {
+  return (
+    <Suspense fallback={<LoadingView />}> 
+      <CallbackInner />
+    </Suspense>
+  );
+}
+
+function LoadingView() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-white p-6">
+      <div className="max-w-md w-full text-center">
+        <h1 className="text-xl font-semibold text-gray-900">Signing you in…</h1>
+        <p className="mt-2 text-sm text-gray-600">Completing Google authentication.</p>
+      </div>
+    </div>
+  );
+}
+
+function CallbackInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [error, setError] = useState("");
@@ -22,7 +38,6 @@ export default function AuthCallbackPage() {
           return;
         }
 
-        // Lazy-load Supabase only on the client to avoid build-time env access
         const { getSupabase } = await import("@/lib/supabaseClient");
         const supabase = getSupabase();
         const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(window.location.href);
@@ -31,7 +46,6 @@ export default function AuthCallbackPage() {
           return;
         }
 
-        // Optional: small delay to ensure session propagation
         setTimeout(() => {
           if (!isMounted) return;
           router.replace("/");
@@ -53,9 +67,7 @@ export default function AuthCallbackPage() {
         <h1 className="text-xl font-semibold text-gray-900">Signing you in…</h1>
         <p className="mt-2 text-sm text-gray-600">Completing Google authentication.</p>
         {error && (
-          <div className="mt-4 text-sm text-red-600">
-            {error}
-          </div>
+          <div className="mt-4 text-sm text-red-600">{error}</div>
         )}
       </div>
     </div>

--- a/app/components/SignInModal.jsx
+++ b/app/components/SignInModal.jsx
@@ -1,6 +1,6 @@
 "use client"
 import { useState } from "react"
-import { supabase } from "@/lib/supabaseClient"
+import { getSupabase } from "@/lib/supabaseClient"
 
 export default function SignInModal({ open, onClose }) {
   const [email, setEmail] = useState("")
@@ -9,11 +9,15 @@ export default function SignInModal({ open, onClose }) {
 
   if (!open) return null
 
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || (typeof window !== "undefined" ? window.location.origin : "")
+  const callbackUrl = `${baseUrl}/auth/callback`
+
   async function signInWithGoogle() {
     setError("")
+    const supabase = getSupabase()
     const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
-      options: { redirectTo: window.location.href }
+      options: { redirectTo: callbackUrl }
     })
     if (error) setError(error.message)
   }
@@ -21,9 +25,10 @@ export default function SignInModal({ open, onClose }) {
   async function signInWithEmail(e) {
     e.preventDefault()
     setError("")
+    const supabase = getSupabase()
     const { error } = await supabase.auth.signInWithOtp({
       email,
-      options: { emailRedirectTo: window.location.href }
+      options: { emailRedirectTo: callbackUrl }
     })
     if (error) setError(error.message)
     else setSent(true)

--- a/app/page.js
+++ b/app/page.js
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import Script from "next/script";
 import Link from "next/link";
-import { supabase } from "@/lib/supabaseClient";
+import { getSupabase } from "@/lib/supabaseClient";
 import SignInModal from "@/app/components/SignInModal";
 
 function HomeGeneratorSection() {
@@ -23,6 +23,7 @@ function HomeGeneratorSection() {
 
   const fetchBalance = async () => {
     try {
+      const supabase = getSupabase();
       const { data: { user } } = await supabase.auth.getUser();
       if (user) {
         const { data, error } = await supabase.from("credits").select("balance").eq("user_id", user.id).single();
@@ -38,6 +39,7 @@ function HomeGeneratorSection() {
   };
 
   const handleGenerate = async () => {
+    const supabase = getSupabase();
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) {
       setShowSignIn(true);

--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -1,7 +1,18 @@
 import { createClient } from '@supabase/supabase-js'
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  { auth: { persistSession: true, detectSessionInUrl: true } }
-)
+let cachedClient = null
+
+export function getSupabase() {
+  if (cachedClient) return cachedClient
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!url || !anonKey) {
+    // Avoid throwing during module import; only throw if the client is actually requested at runtime
+    throw new Error('Supabase client requested without NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY')
+  }
+
+  cachedClient = createClient(url, anonKey, { auth: { persistSession: true, detectSessionInUrl: true } })
+  return cachedClient
+}


### PR DESCRIPTION
Fix Google authentication crash by adding a Supabase OAuth callback page and lazy-loading the Supabase client to prevent SSR errors.

The Google OAuth flow previously redirected directly to the homepage, causing a crash as the code exchange was not completed. Additionally, the Supabase client was initialized at module scope, leading to build-time errors when environment variables were not available during server-side rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6beb5fe-dd34-4dde-b30b-99a9a0c9a607">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6beb5fe-dd34-4dde-b30b-99a9a0c9a607">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

